### PR TITLE
Move flow-bin to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "razzle": "^2.2.0"
   },
   "peerDependencies": {
-    "flow-bin": "^0.x",
+    "flow-bin": "^0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razzle-plugin-flow",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use Flow with Razzle",
   "main": "index.js",
   "repository": "git@github.com:pugnascotia/razzle-plugin-flow.git",
@@ -12,11 +12,12 @@
   "dependencies": {
     "babel-preset-flow": "^6.23.0",
     "eslint-plugin-flowtype": "^2.49.3",
-    "flow-bin": "^0.74.0",
     "flow-webpack-plugin": "^1.2.0"
   },
   "devDependencies": {
     "razzle": "^2.2.0"
   },
-  "peerDependencies": {}
+  "peerDependencies": {
+    "flow-bin": "^0.x",
+  }
 }


### PR DESCRIPTION
Since flow is stuck under 0.x versioning, razzle-plugin-flow was stuck using an old version. I moved it to a peerDependency and changed the semver to allow end users to pick their own version.